### PR TITLE
Update deployment stategy

### DIFF
--- a/helm/minecraft/templates/deployment.yaml
+++ b/helm/minecraft/templates/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app: minecraft-server
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: minecraft-server


### PR DESCRIPTION
The default deployment strategy uses rolling updates, which causes multiple minecraft pods to be started up at the same time. This is a problem since they try and share the same world volume. This can block the startup of the server pod as only a single minecraft server can access a world at once.

Changing the strategy to Recreate stops this, and only has a single pod running at once.